### PR TITLE
Add category collection

### DIFF
--- a/peer-prep-be/src/controllers/categories.go
+++ b/peer-prep-be/src/controllers/categories.go
@@ -74,8 +74,10 @@ func CreateCategory(c echo.Context) error {
 	// 	return c.JSON(http.StatusBadRequest, responses.StatusResponse{Message: "Category already exists"})
 	// }
 
+	newCategoryId := primitive.NewObjectID()
+
 	newCategory := models.Category{
-		Category_id:   primitive.NewObjectID(),
+		Category_id:   newCategoryId,
 		Category_name: category.Category_name,
 	}
 
@@ -98,6 +100,8 @@ func CreateCategory(c echo.Context) error {
 			Message: err.Error(),
 		})
 	}
+	
+	updateResult.UpsertedID = newCategoryId;
 
 	// Check if a new category was created or if it was already existing
 	if updateResult.UpsertedCount > 0 {
@@ -105,6 +109,7 @@ func CreateCategory(c echo.Context) error {
 		return c.JSON(http.StatusCreated, responses.StatusResponse{
 			Status: http.StatusCreated,
 			Message: "Category created successfully",
+			Data: &echo.Map{"data": updateResult},
 		})
 	}
 
@@ -143,7 +148,7 @@ func UpdateCategory(c echo.Context) error {
 	}
 
 	// Perform the Update operation
-	_, err = categoriesCollection.UpdateOne(ctx, bson.M{"_id": categoryId}, update)
+	updateResult, err := categoriesCollection.UpdateOne(ctx, bson.M{"_id": categoryId}, update)
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
@@ -155,6 +160,7 @@ func UpdateCategory(c echo.Context) error {
 	return c.JSON(http.StatusOK, responses.StatusResponse{
 		Status:  http.StatusOK,
 		Message: "Category updated successfully",
+		Data: &echo.Map{"data": updateResult},
 	})
 }
 

--- a/peer-prep-be/src/controllers/categories.go
+++ b/peer-prep-be/src/controllers/categories.go
@@ -26,6 +26,7 @@ func GetCategories(c echo.Context) error {
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Status: http.StatusInternalServerError,
 			Message: err.Error(),
 		})
 	}
@@ -33,11 +34,13 @@ func GetCategories(c echo.Context) error {
 	var categories []models.Category
 	if err = cursor.All(ctx, &categories); err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Status: http.StatusInternalServerError,
 			Message: err.Error(),
 		})
 	}
 
 	return c.JSON(http.StatusOK, responses.StatusResponse{
+		Status: http.StatusOK,
 		Message: "Success",
 		Data:    &echo.Map{"categories": categories},
 	})
@@ -51,6 +54,7 @@ func CreateCategory(c echo.Context) error {
 
 	if err := c.Bind(&category); err != nil {
 		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Status:  http.StatusBadRequest,
 			Message: err.Error(),
 		})
 	}
@@ -90,6 +94,7 @@ func CreateCategory(c echo.Context) error {
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Status: http.StatusInternalServerError,
 			Message: err.Error(),
 		})
 	}
@@ -98,11 +103,13 @@ func CreateCategory(c echo.Context) error {
 	if updateResult.UpsertedCount > 0 {
 		// A new category was created
 		return c.JSON(http.StatusCreated, responses.StatusResponse{
+			Status: http.StatusCreated,
 			Message: "Category created successfully",
 		})
 	}
 
 	return c.JSON(http.StatusConflict, responses.StatusResponse{
+		Status: http.StatusConflict,
 		Message: "Category already exists",
 	})
 }
@@ -116,6 +123,7 @@ func UpdateCategory(c echo.Context) error {
 	_, err := primitive.ObjectIDFromHex(categoryId)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Status:  http.StatusBadRequest,
 			Message: "Invalid category ID: " + err.Error(),
 		})
 	}
@@ -123,6 +131,7 @@ func UpdateCategory(c echo.Context) error {
 	var category models.Category
 	if err := c.Bind(&category); err != nil {
 		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Status:  http.StatusBadRequest,
 			Message: err.Error(),
 		})
 	}
@@ -138,11 +147,13 @@ func UpdateCategory(c echo.Context) error {
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Status:  http.StatusInternalServerError,
 			Message: err.Error(),
 		})
 	}
 
 	return c.JSON(http.StatusOK, responses.StatusResponse{
+		Status:  http.StatusOK,
 		Message: "Category updated successfully",
 	})
 }
@@ -155,6 +166,7 @@ func DeleteCategory(c echo.Context) error {
 	_, err := primitive.ObjectIDFromHex(categoryId)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Status:  http.StatusBadRequest,
 			Message: "Invalid category ID: " + err.Error(),
 		})
 	}
@@ -163,11 +175,13 @@ func DeleteCategory(c echo.Context) error {
 
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Status:  http.StatusInternalServerError,
 			Message: err.Error(),
 		})
 	}
 
 	return c.JSON(http.StatusOK, responses.StatusResponse{
+		Status:  http.StatusOK,
 		Message: "Category deleted successfully",
 	})
 }

--- a/peer-prep-be/src/controllers/categories.go
+++ b/peer-prep-be/src/controllers/categories.go
@@ -1,0 +1,165 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/CS3219-AY2425S1/cs3219-ay2425s1-project-g01/peer-prep-be/src/configs"
+	"github.com/CS3219-AY2425S1/cs3219-ay2425s1-project-g01/peer-prep-be/src/models"
+	"github.com/CS3219-AY2425S1/cs3219-ay2425s1-project-g01/peer-prep-be/src/responses"
+	"github.com/labstack/echo/v4"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var categoriesCollection *mongo.Collection = configs.GetCollection(configs.DB, "categories")
+
+func GetCategories(c echo.Context) error {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cursor, err := categoriesCollection.Find(ctx, bson.M{})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Message: err.Error(),
+		})
+	}
+
+	var categories []models.Category
+	if err = cursor.All(ctx, &categories); err != nil {
+		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Message: err.Error(),
+		})
+	}
+
+	return c.JSON(http.StatusOK, responses.StatusResponse{
+		Message: "Success",
+		Data:    &echo.Map{"categories": categories},
+	})
+}
+
+func CreateCategory(c echo.Context) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// var existingCategory models.Category
+	var category models.Category
+	defer cancel()
+
+	if err := c.Bind(&category); err != nil {
+		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Message: err.Error(),
+		})
+	}
+
+	// Validate Category Name
+	if validationErr := validate.Struct(&category); validationErr != nil {
+		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Status:  http.StatusBadRequest,
+			Message: errMessage,
+			Data:    &echo.Map{"data": validationErr.Error()},
+		})
+	}
+
+	// Duplicate handling
+	// err := categoriesCollection.FindOne(ctx, bson.M{"categoryName": category.CategoryName}).Decode(&existingCategory)
+	// if err == nil {
+	// 	return c.JSON(http.StatusBadRequest, responses.StatusResponse{Message: "Category already exists"})
+	// }
+
+	newCategory := models.Category{
+		Category_id:   primitive.NewObjectID(),
+		Category_name: category.Category_name,
+	}
+
+	// Insert new if it does not exist, case insensitive
+	_, err := categoriesCollection.UpdateOne(ctx,
+		bson.M{"category_name": newCategory.Category_name}, // Filter by category_name only, not the obj
+		bson.M{"$setOnInsert": bson.M{
+			"category_id":   newCategory.Category_id,
+			"category_name": newCategory.Category_name,
+		}},
+		options.Update().SetUpsert(true).SetCollation(&options.Collation{
+			Locale:   "en",
+			Strength: 2, // Case-insensitive comparison
+		}),
+	)
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Message: err.Error(),
+		})
+	}
+
+	return c.JSON(http.StatusCreated, responses.StatusResponse{
+		Message: "Category created successfully",
+	})
+}
+
+// Updates a category, e.g. singular -> plural
+func UpdateCategory(c echo.Context) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	categoryId := c.Param("categoryId")
+	_, err := primitive.ObjectIDFromHex(categoryId)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Message: "Invalid category ID: " + err.Error(),
+		})
+	}
+
+	var category models.Category
+	if err := c.Bind(&category); err != nil {
+		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Message: err.Error(),
+		})
+	}
+
+	update := bson.M{
+		"$set": bson.M{
+			"category_name": category.Category_name,
+		},
+	}
+
+	// Perform the Update operation
+	_, err = categoriesCollection.UpdateOne(ctx, bson.M{"_id": categoryId}, update)
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Message: err.Error(),
+		})
+	}
+
+	return c.JSON(http.StatusOK, responses.StatusResponse{
+		Message: "Category updated successfully",
+	})
+}
+
+func DeleteCategory(c echo.Context) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	categoryId := c.Param("categoryId")
+	_, err := primitive.ObjectIDFromHex(categoryId)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, responses.StatusResponse{
+			Message: "Invalid category ID: " + err.Error(),
+		})
+	}
+
+	_, err = categoriesCollection.DeleteOne(ctx, bson.M{"_id": categoryId})
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{
+			Message: err.Error(),
+		})
+	}
+
+	return c.JSON(http.StatusOK, responses.StatusResponse{
+		Message: "Category deleted successfully",
+	})
+}

--- a/peer-prep-be/src/controllers/categories.go
+++ b/peer-prep-be/src/controllers/categories.go
@@ -76,7 +76,7 @@ func CreateCategory(c echo.Context) error {
 	}
 
 	// Insert new if it does not exist, case insensitive
-	_, err := categoriesCollection.UpdateOne(ctx,
+	updateResult, err := categoriesCollection.UpdateOne(ctx,
 		bson.M{"category_name": newCategory.Category_name}, // Filter by category_name only, not the obj
 		bson.M{"$setOnInsert": bson.M{
 			"category_id":   newCategory.Category_id,
@@ -94,8 +94,16 @@ func CreateCategory(c echo.Context) error {
 		})
 	}
 
+	// Check if a new category was created or if it was already existing
+	if updateResult.UpsertedCount > 0 {
+		// A new category was created
+		return c.JSON(http.StatusCreated, responses.StatusResponse{
+			Message: "Category created successfully",
+		})
+	}
+
 	return c.JSON(http.StatusCreated, responses.StatusResponse{
-		Message: "Category created successfully",
+		Message: "Category already exists",
 	})
 }
 

--- a/peer-prep-be/src/controllers/categories.go
+++ b/peer-prep-be/src/controllers/categories.go
@@ -102,7 +102,7 @@ func CreateCategory(c echo.Context) error {
 		})
 	}
 
-	return c.JSON(http.StatusCreated, responses.StatusResponse{
+	return c.JSON(http.StatusConflict, responses.StatusResponse{
 		Message: "Category already exists",
 	})
 }

--- a/peer-prep-be/src/controllers/question.go
+++ b/peer-prep-be/src/controllers/question.go
@@ -46,10 +46,10 @@ func CreateQuestion(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, responses.StatusResponse{Status: http.StatusBadRequest, Message: errMessage, Data: &echo.Map{"data": "Question with the same title already exists."}})
 	}
 
-	new_question_id := primitive.NewObjectID()
+	newQuestionId := primitive.NewObjectID()
 
 	newQuestion := models.Question{
-		Question_id:          new_question_id,
+		Question_id:          newQuestionId,
 		Question_title:       question.Question_title,
 		Question_description: question.Question_description,
 		Question_categories:  question.Question_categories,
@@ -62,7 +62,7 @@ func CreateQuestion(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, responses.StatusResponse{Status: http.StatusInternalServerError, Message: errMessage, Data: &echo.Map{"data": err.Error()}})
 	}
 
-	result.InsertedID = new_question_id
+	result.InsertedID = newQuestionId
 	return c.JSON(http.StatusCreated, responses.StatusResponse{Status: http.StatusCreated, Message: successMessage, Data: &echo.Map{"data": result}})
 }
 

--- a/peer-prep-be/src/models/category_model.go
+++ b/peer-prep-be/src/models/category_model.go
@@ -1,0 +1,8 @@
+package models
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+type Category struct {
+	Category_id   primitive.ObjectID `json:"category_id,omitempty"`
+	Category_name string             `json:"category_name" validate:"required"`
+}

--- a/peer-prep-be/src/routes/categories_route.go
+++ b/peer-prep-be/src/routes/categories_route.go
@@ -1,0 +1,13 @@
+package routes
+
+import (
+	"github.com/CS3219-AY2425S1/cs3219-ay2425s1-project-g01/peer-prep-be/src/controllers"
+	"github.com/labstack/echo/v4"
+)
+
+func CategoriesRoute(e *echo.Echo) {
+	e.GET("/categories", controllers.GetCategories)
+	e.PUT("/categories/:categoryId", controllers.UpdateCategory)
+	e.POST("/categories", controllers.CreateCategory)
+	e.DELETE("/categories/:categoryId", controllers.DeleteCategory)
+}

--- a/peer-prep-be/src/routes/question_route.go
+++ b/peer-prep-be/src/routes/question_route.go
@@ -7,9 +7,10 @@ import (
 
 func QuestionRoute(e *echo.Echo) {
 	e.GET("/questions/:questionId", controllers.GetQuestion)
-	e.GET("/questions", controllers.GetQuestions) 
+	e.GET("/questions", controllers.GetQuestions)
 	e.GET("/questions/search", controllers.SearchQuestion)
 	e.POST("/question", controllers.CreateQuestion)
 	e.PUT("/questions/:questionId", controllers.UpdateQuestion)
 	e.DELETE("/questions/:questionId", controllers.DeleteQuestion)
+	e.GET("/questionCategories", controllers.GetDistinctQuestionCategories)
 }

--- a/peer-prep-be/src/routes/question_route.go
+++ b/peer-prep-be/src/routes/question_route.go
@@ -12,5 +12,5 @@ func QuestionRoute(e *echo.Echo) {
 	e.POST("/question", controllers.CreateQuestion)
 	e.PUT("/questions/:questionId", controllers.UpdateQuestion)
 	e.DELETE("/questions/:questionId", controllers.DeleteQuestion)
-	e.GET("/questionCategories", controllers.GetDistinctQuestionCategories)
+	e.GET("/questions/categories", controllers.GetDistinctQuestionCategories)
 }

--- a/peer-prep-be/src/server.go
+++ b/peer-prep-be/src/server.go
@@ -24,6 +24,7 @@ func main() {
 	}))
 
 	routes.QuestionRoute(e)
+	routes.CategoriesRoute(e)
 
 	e.GET("/", func(c echo.Context) error {
 		return c.String(http.StatusOK, "Hello, World!")


### PR DESCRIPTION

- add CRUD for categories 
   - `GET /categories` used to render the list of categories in Edit/Add question FE (@AidenLYT)
   - `POST /categories` for admin to create new categories via the dropdown when they wish to edit/add questions
   -  update/delete categories included for completion, but don't necessarily need to be integrated to frontend at the moment

- trigger the addition of new categories to the category collection when adding/updating question (if category does not already exist in the collection)
  - note: deleted questions have no effect on the category collection,  category is retained for future use when adding/editing questions
- add `GET /questionCategories` endpoint to retrieve active categories (i.e. categories that are tagged to at least 1 qn at the moment) 